### PR TITLE
Parse provided property paths

### DIFF
--- a/parser/document.go
+++ b/parser/document.go
@@ -28,7 +28,7 @@ type Section struct {
 }
 
 type Property struct {
-	Name        string
+	Path        Path
 	Description Comment
 	Type        string
 	Default     string
@@ -79,7 +79,7 @@ func Load(filename string) (*Document, error) {
 
 		sectionIdx := len(document.Sections) - 1
 		document.Sections[sectionIdx].Properties = append(document.Sections[sectionIdx].Properties, Property{
-			Name:        node.Path.String(),
+			Path:        node.Path,
 			Description: comment,
 			Type:        getTypeOf(node, comment),
 			Default:     getDefaultValue(node, comment),
@@ -160,9 +160,15 @@ func parseCommentsOntoDocument(path Path, document *Document, comments []Comment
 				}
 			}
 
+			path, err := ParsePath(name)
+			if err != nil {
+				log.Printf("could not parse property path %q: %s\n", name, err)
+				continue
+			}
+
 			sectionIdx := len(document.Sections) - 1
 			document.Sections[sectionIdx].Properties = append(document.Sections[sectionIdx].Properties, Property{
-				Name:        name,
+				Path:        path,
 				Description: comment,
 				Type:        getTypeOf(parsedNode, comment),
 				Default:     "undefined",

--- a/parser/path.go
+++ b/parser/path.go
@@ -1,8 +1,10 @@
 package parser
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 )
 
@@ -30,6 +32,54 @@ func (i indexPathComponent) Append(idx int, w io.Writer) {
 
 type Path []pathComponent
 
+func ParsePath(pathString string) (Path, error) {
+	scanner := bytes.NewBufferString(pathString)
+
+	path := Path{}
+
+	for {
+		switch k, last, err := runesUntil(scanner, runeSet([]rune{'[', '.'})); {
+		case err == io.EOF && len(k) > 0:
+			return append(path, stringPathComponent(k)), nil
+		case err == io.EOF && len(k) == 0:
+			return path, nil
+		case err != nil:
+			return path, err
+		case last == '[':
+			path = append(path, stringPathComponent(k))
+
+			betweenBrackets, _, err := runesUntil(scanner, runeSet([]rune{']'}))
+			if err != nil {
+				return path, fmt.Errorf("unexpected end of path")
+			}
+
+			if len(betweenBrackets) == 0 {
+				return path, fmt.Errorf("unexpected empty array index")
+			}
+
+			if betweenBrackets[0] == '"' && betweenBrackets[len(betweenBrackets)-1] == '"' {
+				// betweenBrackets is a string
+				path = append(path, stringPathComponent(betweenBrackets[1:len(betweenBrackets)-1]))
+			} else {
+				idx, err := strconv.Atoi(string(betweenBrackets))
+				if err != nil {
+					return path, fmt.Errorf("unexpected array index: %q", betweenBrackets)
+				}
+
+				path = append(path, indexPathComponent(idx))
+			}
+
+			if r, _, e := scanner.ReadRune(); e == nil && r != '.' {
+				return path, fmt.Errorf("unexpected token %q", r)
+			}
+		case last == '.':
+			path = append(path, stringPathComponent(k))
+		default:
+			return nil, fmt.Errorf("parse error: unexpected token %v", last)
+		}
+	}
+}
+
 func (p Path) WithProperty(part string) Path {
 	return append(p, stringPathComponent(part))
 }
@@ -53,4 +103,37 @@ func (p Path) String() string {
 		part.Append(i, &sb)
 	}
 	return sb.String()
+}
+
+func runeSet(r []rune) map[rune]bool {
+	s := make(map[rune]bool, len(r))
+	for _, rr := range r {
+		s[rr] = true
+	}
+	return s
+}
+
+func runesUntil(in io.RuneReader, stop map[rune]bool) ([]rune, rune, error) {
+	v := []rune{}
+	for {
+		switch r, _, e := in.ReadRune(); {
+		case e != nil:
+			return v, r, e
+		case inMap(r, stop):
+			return v, r, nil
+		case r == '\\':
+			next, _, e := in.ReadRune()
+			if e != nil {
+				return v, next, e
+			}
+			v = append(v, next)
+		default:
+			v = append(v, r)
+		}
+	}
+}
+
+func inMap(r rune, m map[rune]bool) bool {
+	_, ok := m[r]
+	return ok
 }

--- a/parser/path_test.go
+++ b/parser/path_test.go
@@ -1,0 +1,59 @@
+package parser
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParsePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected Path
+		wantErr  bool
+	}{
+		{
+			name:     "Empty path",
+			path:     "",
+			expected: Path{},
+			wantErr:  false,
+		},
+		{
+			name:     "Single string component",
+			path:     "foo",
+			expected: Path{stringPathComponent("foo")},
+			wantErr:  false,
+		},
+		{
+			name:     "Single index component",
+			path:     "foo[0]",
+			expected: Path{stringPathComponent("foo"), indexPathComponent(0)},
+			wantErr:  false,
+		},
+		{
+			name:     "Multiple components",
+			path:     "foo.bar[0].baz",
+			expected: Path{stringPathComponent("foo"), stringPathComponent("bar"), indexPathComponent(0), stringPathComponent("baz")},
+			wantErr:  false,
+		},
+		{
+			name:     "Invalid path 2",
+			path:     "foo[0]aa",
+			expected: Path{stringPathComponent("foo"), indexPathComponent(0)},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParsePath(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParsePath() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("ParsePath() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/render/markdown-table
+++ b/render/markdown-table
@@ -55,7 +55,7 @@
     {{- range .Properties }}
 <tr>
 
-<td>{{ .Name }}</td>
+<td>{{ .Path }}</td>
 <td>
 
 {{- range .Description.Segments }}


### PR DESCRIPTION
Instead of treating property paths as strings in the Property struct, I propose we store the path there.
This will help use to build trees using these path segments.